### PR TITLE
PlayerData Reading Fix

### DIFF
--- a/core/src/com/team3gdx/game/screen/LeaderBoard.java
+++ b/core/src/com/team3gdx/game/screen/LeaderBoard.java
@@ -55,7 +55,7 @@ public class LeaderBoard implements Screen, TextInputListener {
 			String text = handle.readString();
 			String[] entries = text.split("\\n");
 			for (String s : entries) {
-				if(!s.equals("s")) {
+				if(!s.trim().equals("s")) {
 					String[] parts = s.split(";");
 					String name = parts[0];
 					String stringScore = parts[1].trim();


### PR DESCRIPTION
Fixes runtime at launch when reading data from a populated `playerData.txt` file.

An unpopulated file looks as below:
```
s
```

A populated file looks as below:
```
s\r\n
PLAYER1;389\r\n
PLAYER1;175
```

`\r\n` is the CRLF End-of-Line encoding. The parsing code splits line by `\n` and thus compares `s` to `s\r`; failing that, it attempts to parse `s` as a leaderboard entry (in the format `<playerName>;<score>`, hence an indexing error after splitting `s` by `;` and attempting to access index 1).

An alternative approach to fixing this is having the initial file data be split by a regex representation of [`\r`OR`\n`]- however, this would only serve to add compatibility with Classic Mac OS (2001 and earlier), which is outside the scope of the project.