### PR TITLE
Wrongful Game Data Persistence Fix

### DIFF
--- a/core/src/com/team3gdx/game/screen/GameScreen.java
+++ b/core/src/com/team3gdx/game/screen/GameScreen.java
@@ -86,7 +86,7 @@ public class GameScreen implements Screen {
 	OrthographicCamera uiCamera;
 	public static OrthographicCamera worldCamera;
 
-	public static Customer currentWaitingCustomer = null;
+	public static Customer currentWaitingCustomer;
 
 	public enum STATE {
 		Pause, Continue, main, audio
@@ -113,12 +113,12 @@ public class GameScreen implements Screen {
 	public static Control control;
 	TiledMapRenderer tiledMapRenderer;
 	public TiledMap map1;
-	public static Cook[] cooks = { new Cook(new Vector2(64 * 5, 64 * 3), 1), new Cook(new Vector2(64 * 5, 64 * 5), 2), new Cook(new Vector2(64 * 5, 64 * 7), 3) };
-	public static int currentCookIndex = 0;
-	public static Cook cook = cooks[currentCookIndex];
+	public static Cook[] cooks;
+	public static int currentCookIndex;
+	public static Cook cook;
 	public static CustomerController cc;
 	InputMultiplexer multi;
-	StationManager stationManager = new StationManager();
+	StationManager stationManager;
 
 	/**
 	 * Constructor to initialise game screen;
@@ -130,6 +130,7 @@ public class GameScreen implements Screen {
 		this.game = game;
 		this.ms = ms;
 		this.calculateBoxMaths();
+		currentWaitingCustomer = null;
 		control = new Control();
 		// map = new TmxMapLoader().load("map/art_map/prototype_map.tmx");
 		map1 = new TmxMapLoader().load("map/art_map/customertest.tmx");
@@ -137,6 +138,10 @@ public class GameScreen implements Screen {
 		constructCollisionData(map1);
 		cc = new CustomerController(map1);
 		cc.spawnCustomer();
+		cooks = new Cook[]{new Cook(new Vector2(64 * 5, 64 * 3), 1), new Cook(new Vector2(64 * 5, 64 * 5), 2), new Cook(new Vector2(64 * 5, 64 * 7), 3)};
+		currentCookIndex = 0;
+		cook = cooks[currentCookIndex];
+		stationManager = new StationManager();
 	}
 
 	/**

--- a/core/src/com/team3gdx/game/station/StationManager.java
+++ b/core/src/com/team3gdx/game/station/StationManager.java
@@ -23,9 +23,13 @@ public class StationManager {
 	/**
 	 * A Map representing every station and its (x, y) coordinates.
 	 */
-	public static Map<Vector2, Station> stations = new HashMap<Vector2, Station>();
+	public static Map<Vector2, Station> stations;
 
 	SpriteBatch batch;
+
+	public StationManager() {
+		stations = new HashMap<Vector2, Station>();
+	}
 
 	/**
 	 * Checks every station for ingredients and updates them accordingly.


### PR DESCRIPTION
Certain static attributes of `GameScreen` and `StationManager` were instantiated outside of their owners' constructors. As they were static (meaning shared across all instances of their owner class), their values were not actually instantiated anew when their owner classes were. This meant that, most prominently (and visually), chef and station data (and ingredients as they are contained as objects in chef inventory stacks, though the issue did not lie with them).

An alternate solution to this is reducing the amount of static attributes across classes, though this would be more work than it is perhaps worth as there are _**many**_ static contexts in the codebase.

Resolves #24 