### PR TITLE
Fixes Flipping Keybind

### DIFF
--- a/core/src/com/team3gdx/game/util/Control.java
+++ b/core/src/com/team3gdx/game/util/Control.java
@@ -82,7 +82,7 @@ public class Control extends InputAdapter implements InputProcessor {
 		case Keys.E:
 			drop = true;
 			break;
-		case Keys.SPACE:
+		case Keys.F:
 			flip = true;
 			break;
 		case Keys.TAB:


### PR DESCRIPTION
The flipping keybind was changed to `SPACE` in PR #2 (a5f0e29a3d3439de7dd7132c67e9cc7556b8366b). Note: tooltip was not changed to reflect the previous change.